### PR TITLE
add validation for HYTALE_AUTH_MODE environment variable

### DIFF
--- a/scripts/hytale/hytale_options.sh
+++ b/scripts/hytale/hytale_options.sh
@@ -63,10 +63,14 @@ else
 fi
 
 # Authentication Mode
-log_step "Auth Mode"
+log_step "Authentication Mode"
 if [ -n "${HYTALE_AUTH_MODE:-}" ]; then
-    export HYTALE_AUTH_MODE_OPT="--auth-mode=$HYTALE_AUTH_MODE"
-    printf "${GREEN}$HYTALE_AUTH_MODE${NC}\n"
+    if [ "$HYTALE_AUTH_MODE" = "authenticated" ] || [ "$HYTALE_AUTH_MODE" = "offline" ]; then
+        export HYTALE_AUTH_MODE_OPT="--auth-mode=$HYTALE_AUTH_MODE"
+        printf "${GREEN}$HYTALE_AUTH_MODE${NC}\n"
+    else
+        printf "${RED}invalid: $HYTALE_AUTH_MODE${NC} (use 'authenticated' or 'offline')${NC}\n"
+    fi
 else
     printf "${DIM}default (authenticated)${NC}\n"
 fi


### PR DESCRIPTION
Fixes #49 users were setting `HYTALE_AUTH_MODE='TRUE'` (as reported in issue #49), but the Hytale server only accepts `authenticated` or `offline` as valid values. This resulted in an `IllegalArgumentException` during server startup, causing the container to fail.

**Example from issue #49:**

```bash
-e 'HYTALE_AUTH_MODE'='TRUE'  # ❌ Invalid - causes server crash
```

## Solution

Added input validation for the `HYTALE_AUTH_MODE` environment variable to:

1. **Validate input** - Only accept `authenticated` or `offline` as valid values
2. **Provide clear feedback** - Display a helpful error message when an invalid value is used
3. **Prevent silent failures** - Invalid values no longer get passed to the server

## Testing

```bash
# Valid values
HYTALE_AUTH_MODE=authenticated  # Shows: authenticated (green)
HYTALE_AUTH_MODE=offline        # Shows: offline (green)

# Invalid value (reproduces issue #49)
HYTALE_AUTH_MODE=TRUE           # Shows: invalid: TRUE (use 'authenticated' or 'offline') (red)

# Default behavior
# (unset)                       # Shows: default (authenticated) (dim)
```