### PR TITLE
Add 'insecure' option to HYTALE_AUTH_MODE

### DIFF
--- a/scripts/hytale/hytale_options.sh
+++ b/scripts/hytale/hytale_options.sh
@@ -65,11 +65,11 @@ fi
 # Authentication Mode
 log_step "Authentication Mode"
 if [ -n "${HYTALE_AUTH_MODE:-}" ]; then
-    if [ "$HYTALE_AUTH_MODE" = "authenticated" ] || [ "$HYTALE_AUTH_MODE" = "offline" ]; then
+    if [ "$HYTALE_AUTH_MODE" = "authenticated" ] || [ "$HYTALE_AUTH_MODE" = "insecure" ] || [ "$HYTALE_AUTH_MODE" = "offline" ]; then
         export HYTALE_AUTH_MODE_OPT="--auth-mode=$HYTALE_AUTH_MODE"
         printf "${GREEN}$HYTALE_AUTH_MODE${NC}\n"
     else
-        printf "${RED}invalid: $HYTALE_AUTH_MODE${NC} (use 'authenticated' or 'offline')${NC}\n"
+        printf "${RED}invalid: $HYTALE_AUTH_MODE${NC} (use 'authenticated', 'insecure' or 'offline')${NC}\n"
     fi
 else
     printf "${DIM}default (authenticated)${NC}\n"


### PR DESCRIPTION
Hey there,

I am the maintainer of [Numdrassl](https://github.com/Numdrassl/proxy), a reverse proxy that works for Hytale. Multiple users have notified me that my plugin does not work with your docker image. Upon further inspection, it seems that the insecure option is missing.

<img width="874" height="78" alt="image" src="https://github.com/user-attachments/assets/fa0a4280-047e-41f4-816f-9b927a1c8e07" />


Please can we get this resolved?