### PR TITLE
[PATCH] Fix interactive console: enable stdin (docker attach) during …

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,8 +171,9 @@ fi
 
 printf "\n"
 
-# Execute Java server as non-root user
-exec $RUNTIME sh -c "cat \"$AUTH_PIPE\" - | exec stdbuf -oL -eL java $JAVA_ARGS \
+
++# Execute Java server as non-root user
+exec $RUNTIME sh -c "( tail -f \"$AUTH_PIPE\" & cat ) | exec stdbuf -oL -eL java $JAVA_ARGS \
     -Duser.timezone=\"$TZ\" \
     -Dterminal.jline=false \
     -Dterminal.ansi=true \


### PR DESCRIPTION
…auth pipe read

The current entrypoint uses `cat "$AUTH_PIPE" -` to combine the auth pipe and standard input. However, `cat` reads sequentially. It waits for the named pipe to send EOF before it starts reading from stdin (-).

Since the auth pipe is meant to stay open/persistent, standard input (docker attach) is never reached, effectively blocking manual commands.

This patch replaces the sequential `cat` with a parallel approach using a subshell:
1. `tail -f` reads the auth pipe in the background.
2. `cat` reads stdin (the user console) in the foreground.

This allows both automated auth commands and manual user commands to reach the server process simultaneously.