### PR TITLE
fix(scripts): restore stdin forwarding to console pipe

### DIFF
--- a/scripts/hytale/hytale_start.sh
+++ b/scripts/hytale/hytale_start.sh
@@ -97,9 +97,9 @@ run_server() {
     RUNTIME_CMD="${RUNTIME:-}"
 
     if [ -n "$RUNTIME_CMD" ]; then
-        $RUNTIME sh -c "( tail -f \"$AUTH_PIPE\" 2>/dev/null || true ) | $java_cmd 2>&1 | stdbuf -oL -eL sed 's/\r$//' | stdbuf -oL -eL tee \"$AUTH_OUTPUT_LOG\""
+        $RUNTIME sh -c "( tail -f \"$AUTH_PIPE\" 2>/dev/null & cat ) | $java_cmd 2>&1 | stdbuf -oL -eL sed 's/\r$//' | stdbuf -oL -eL tee \"$AUTH_OUTPUT_LOG\""
     else
-        ( tail -f "$AUTH_PIPE" 2>/dev/null || true ) | $java_cmd 2>&1 | stdbuf -oL -eL sed 's/\r$//' | stdbuf -oL -eL tee "$AUTH_OUTPUT_LOG"
+        ( tail -f "$AUTH_PIPE" 2>/dev/null & cat ) | $java_cmd 2>&1 | stdbuf -oL -eL sed 's/\r$//' | stdbuf -oL -eL tee "$AUTH_OUTPUT_LOG"
     fi
 }
 


### PR DESCRIPTION
https://github.com/deinfreu/hytale-server-container/issues/124#issue-4842193841

Restored `docker attach` console input. 
`run_server()` in `hytale_start.sh` dropped the `& cat` , so no stdin could reach the server

