### PR TITLE
Make workflows owner agnostic

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -70,10 +70,10 @@ jobs:
         run: |
           BRANCH="${{ github.ref_name }}"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH="${{ github.base_ref_name }}"
+            BRANCH="${{ github.base_ref }}"
           fi
           BASE_SUFFIX="${{ matrix.base_suffix }}"
-          
+
           if [ "$BRANCH" = "main" ]; then
               if [ -z "$BASE_SUFFIX" ]; then
                   TAG_NAME="latest"
@@ -91,7 +91,7 @@ jobs:
               PLATFORMS="linux/amd64,linux/arm64"
               NEEDS_QEMU="true"
           fi
-          
+
           echo "tag_suffix=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "platforms=$PLATFORMS" >> $GITHUB_OUTPUT
           echo "needs_qemu=$NEEDS_QEMU" >> $GITHUB_OUTPUT
@@ -127,7 +127,7 @@ jobs:
           push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           platforms: ${{ steps.context.outputs.platforms }}
           tags: |
-            ghcr.io/deinfreu/hytale-server:${{ steps.context.outputs.tag_suffix }}
-            deinfreu/hytale-server:${{ steps.context.outputs.tag_suffix }}
+            ghcr.io/${{ github.repository_owner }}/hytale-server:${{ steps.context.outputs.tag_suffix }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/hytale-server:${{ steps.context.outputs.tag_suffix }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -78,8 +78,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/deinfreu/hytale-server:${{ steps.set_tag.outputs.tag_prefix }}${{ steps.get_version.outputs.version }}
-            deinfreu/hytale-server:${{ steps.set_tag.outputs.tag_prefix }}${{ steps.get_version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/hytale-server:${{ steps.set_tag.outputs.tag_prefix }}${{ steps.get_version.outputs.version }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/hytale-server:${{ steps.set_tag.outputs.tag_prefix }}${{ steps.get_version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -110,9 +110,9 @@ jobs:
         run: |
           PREVIOUS_TAG="${{ steps.previoustag.outputs.previous_tag }}"
           CURRENT_TAG="${{ github.ref_name }}"
-          
+
           CHANGELOG=$(git log ${PREVIOUS_TAG}..${CURRENT_TAG} --pretty=format:"- %s (%h)" --no-merges || echo "Eerste release")
-          
+
           {
             echo 'changelog<<EOF'
             echo "$CHANGELOG"
@@ -124,14 +124,14 @@ jobs:
         run: |
           PREVIOUS_TAG="${{ steps.previoustag.outputs.previous_tag }}"
           CURRENT_TAG="${{ github.ref_name }}"
-          
+
           # Toont Git auteursnamen (zonder @ aangezien dit geen GitHub handles zijn)
-          CONTRIBUTORS=$(git log --pretty=format:"- %an" --no-merges ${PREVIOUS_TAG}..${CURRENT_TAG} | sort -u | grep -v "deinfreu" || true)
-          
+          CONTRIBUTORS=$(git log --pretty=format:"- %an" --no-merges ${PREVIOUS_TAG}..${CURRENT_TAG} | sort -u | grep -vi "${{ github.repository_owner }}" || true)
+
           if [ -z "$CONTRIBUTORS" ]; then
             CONTRIBUTORS="- Geen externe bijdragen in deze release."
           fi
-          
+
           {
             echo 'contributors<<EOF'
             echo "$CONTRIBUTORS"
@@ -145,17 +145,17 @@ jobs:
           name: ${{ github.ref_name }}
           body: |
             ## Changes since ${{ steps.previoustag.outputs.previous_tag }}
-            
+
             ${{ steps.changelog.outputs.changelog }}
-            
+
             ---
-            
+
             ## Contributors
-            
+
             A special thank you to everyone who contributed to this release!
-            
+
             ${{ steps.contributors.outputs.contributors }}
-            
+
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/sync-metadata.yml
+++ b/.github/workflows/sync-metadata.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           # 1. Fetch metadata with authentication to avoid API rate limits
           TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "${{ secrets.DOCKER_HUB_USERNAME }}", "password": "${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-          JSON_DATA=$(curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/deinfreu/hytale-server/tags/latest-alpine-liberica")
+          JSON_DATA=$(curl -s -H "Authorization: JWT ${TOKEN}" "https://hub.docker.com/v2/repositories/${{ secrets.DOCKER_HUB_USERNAME }}/hytale-server/tags/latest-alpine-liberica")
           
           # 2. Extract size and convert to MB met awk
           SIZE_BYTES=$(echo "$JSON_DATA" | jq -r '.full_size')
@@ -57,7 +57,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: deinfreu/hytale-server
+          repository: ${{ secrets.DOCKER_HUB_USERNAME }}/hytale-server
           short-description: ${{ steps.get_info.outputs.DOCKER_DESC }}
           readme-filepath: DOCKERHUB.md
           enable-url-completion: true


### PR DESCRIPTION
Summary:
- Replace hard-coded image owners in branch, release, and metadata workflows with repository or Docker Hub secret-derived owners.
- Use the supported pull request base ref when resolving branch build tags.
- Keep release contributor filtering owner-agnostic.

Verification:
- ruby -e "require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }" .github/workflows/*.yml
- git diff --check -- .github/workflows
- targeted searches for hard-coded owner references