### PR TITLE
fix: write generated config to the Server/config.json the server reads

### DIFF
--- a/scripts/hytale/hytale_config.sh
+++ b/scripts/hytale/hytale_config.sh
@@ -23,7 +23,10 @@ set -eu
 . "$SCRIPTS_PATH/utils.sh"
 
 # Constants
-readonly CONFIG_FILE="${BASE_DIR:-/home/container}/config.json"
+# The server runs with CWD=$BASE_DIR/Server (see hytale_start.sh: `cd Server`),
+# so it reads/writes Server/config.json — NOT $BASE_DIR/config.json. Manage the
+# file the server actually loads, otherwise env overrides silently never apply.
+readonly CONFIG_FILE="${BASE_DIR:-/home/container}/Server/config.json"
 readonly CONFIG_BACKUP_SUFFIX=".invalid.bak"
 readonly CONFIG_TMP_SUFFIX=".tmp"
 


### PR DESCRIPTION
## Problem
`hytale_config.sh` applies every env-driven override (`HYTALE_SERVER_NAME`, `HYTALE_MOTD`, `HYTALE_PASSWORD`, `HYTALE_MAX_PLAYERS`, etc.) to `$BASE_DIR/config.json`. But the server is launched with `cd Server` (see `hytale_start.sh`), so its working directory is `$BASE_DIR/Server` and it only ever reads/writes **`Server/config.json`**. The managed top-level `config.json` is silently ignored, so none of the env overrides take effect in-game.

## Fix
Point `CONFIG_FILE` at `$BASE_DIR/Server/config.json` so overrides land in the file the server actually loads. `Server/` is created by the binary handler, which runs before this script, so the directory always exists.

## Verification
On a running container: env vars (`HYTALE_SERVER_NAME`/`HYTALE_MOTD`) applied to the top-level `config.json` while the live server kept serving the stale name from `Server/config.json`. With this change the overrides are written to the file the server reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)