### PR TITLE
fix: extract update package into staging so updates actually apply

### DIFF
--- a/scripts/hytale/hytale_update.sh
+++ b/scripts/hytale/hytale_update.sh
@@ -28,17 +28,22 @@ set -eu
 
 extract_and_stage_server() {
     local ZIP_FILE="$1"
+    local STAGING_DIR="$GAME_DIR/updater/staging"
 
     log_step "Extracting to staging area"
-    mkdir -p "$GAME_DIR/updater/staging"
+    rm -rf "$STAGING_DIR"
+    mkdir -p "$STAGING_DIR"
 
     if [ "${DEBUG:-FALSE}" = "TRUE" ]; then
         printf "      ${DIM}↳ Source:${NC} %s\n" "$(basename "$ZIP_FILE")"
-        printf "      ${DIM}↳ Target:${NC} ${GREEN}%s${NC}\n" "$BASE_DIR"
+        printf "      ${DIM}↳ Target:${NC} ${GREEN}%s${NC}\n" "$STAGING_DIR"
     fi
 
-    # Overwrites only archived files; user data/configs/mods untouched
-    if 7z x "$ZIP_FILE" -aoa -bsp1 -mmt=on -o"$BASE_DIR" >/dev/null 2>&1; then
+    # Extract into the staging area (NOT $BASE_DIR): the apply step below copies
+    # from updater/staging/ into the live server dirs. Extracting straight to
+    # $BASE_DIR left staging empty, so the "Missing Server/HytaleServer.jar"
+    # guard always tripped and no update was ever applied.
+    if 7z x "$ZIP_FILE" -aoa -bsp1 -mmt=on -o"$STAGING_DIR" >/dev/null 2>&1; then
         log_success
     else
         log_error "Extraction failed" "Check disk space or 7z compatibility."


### PR DESCRIPTION
## Problem
`extract_and_stage_server()` extracts the update zip with `-o"$BASE_DIR"`, but the apply step immediately after checks for the staged jar under `updater/staging/Server/HytaleServer.jar`. Since nothing is ever written to `updater/staging/`, that guard always fails with *"Invalid update package / Missing Server/HytaleServer.jar"* and exits 1 — so the advertised **"drop a `X.Y.Z.zip` in the data dir and restart"** update flow never worked. A server left running an older build than the client fails to connect (QUIC login aborts with a client-side transport error).

## Fix
Extract into `$GAME_DIR/updater/staging` (cleaned first) so the existing copy-from-staging logic applies the new jar, assets, licenses, and start scripts to the live server directories.

## Notes
- Scoped intentionally to the staging-path bug. The copy step still references the legacy `HytaleServer.aot` filename while newer builds ship `HytaleServer.aot.config`; that's harmless (the JVM ignores a stale AOT cache) and handled in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)