### PR TITLE
chore(scripts): remove dead HytaleServer.aot references

### DIFF
--- a/scripts/checks/permissions.sh
+++ b/scripts/checks/permissions.sh
@@ -41,7 +41,7 @@ fi
 
 log_step "Setting Server Binary Permissions"
 # Make server binaries executable (755)
-find "$GAME_DIR/Server" -maxdepth 1 -type f \( -name "*.jar" -o -name "*.aot" \) -exec chmod 755 {} \; 2>/dev/null || true
+find "$GAME_DIR/Server" -maxdepth 1 -type f -name "*.jar" -exec chmod 755 {} \; 2>/dev/null || true
 log_success
 
 log_step "Setting Executable File Permissions"
@@ -67,7 +67,7 @@ chown -R container:container "$GAME_DIR" 2>/dev/null || true
 log_success
 
 if [ "${DEBUG:-FALSE}" = "TRUE" ]; then
-    printf "      ${DIM}↳ Binaries (.jar, .aot):${NC} ${GREEN}755${NC} (rwxr-xr-x)\n"
+    printf "      ${DIM}↳ Binaries (.jar):${NC} ${GREEN}755${NC} (rwxr-xr-x)\n"
     printf "      ${DIM}↳ Executables (Assets.zip, start.sh, start.bat):${NC} ${GREEN}755${NC} (rwxr-xr-x)\n"
     printf "      ${DIM}↳ Configs (.json, .enc):${NC} ${GREEN}644${NC} (rw-r--r--)\n"
     printf "      ${DIM}↳ Directories:${NC} ${GREEN}755${NC} (rwxr-xr-x)\n"

--- a/scripts/hytale/hytale_start.sh
+++ b/scripts/hytale/hytale_start.sh
@@ -34,7 +34,6 @@ apply_staged_update() {
 
     log_step "Applying staged update"
     cp -f updater/staging/Server/HytaleServer.jar Server/
-    [ -f "updater/staging/Server/HytaleServer.aot" ]   && cp -f updater/staging/Server/HytaleServer.aot Server/
     [ -d "updater/staging/Server/Licenses" ]           && rm -rf Server/Licenses && cp -r updater/staging/Server/Licenses Server/
     [ -f "updater/staging/Assets.zip" ]                && cp -f updater/staging/Assets.zip ./
     rm -rf updater/staging

--- a/scripts/hytale/hytale_update.sh
+++ b/scripts/hytale/hytale_update.sh
@@ -54,7 +54,6 @@ extract_and_stage_server() {
     cd "$GAME_DIR"
     if [ -f "updater/staging/Server/HytaleServer.jar" ]; then
         cp -f updater/staging/Server/HytaleServer.jar Server/
-        [ -f "updater/staging/Server/HytaleServer.aot" ]  && cp -f updater/staging/Server/HytaleServer.aot Server/
         [ -d "updater/staging/Server/Licenses" ]          && rm -rf Server/Licenses && cp -r updater/staging/Server/Licenses Server/
         [ -f "updater/staging/Assets.zip" ]               && cp -f updater/staging/Assets.zip ./
         [ -f "updater/staging/start.sh" ]                 && cp -f updater/staging/start.sh ./


### PR DESCRIPTION
## Summary

Follow-up cleanup to the AppCDS switch (PR #134). Removes the now-dead `HytaleServer.aot` handling that lingered in the update/permissions scripts.

Now that the class-data cache uses dynamic AppCDS (runtime-generated `HytaleServer.jsa`), the shipped `HytaleServer.aot` artifact — tied to Hytale's own JVM build — is never read by our `java` invocation. Copying it on update and chmod'ing it is dead code.

This addresses [Copilot's review note on #134](https://github.com/deinfreu/hytale-server-container/pull/134#discussion_r3563065312), which flagged the inconsistency. One clarification on direction: the review suggested *renaming* those references to `.jsa`, but that isn't correct — the `.jsa` archive is generated at server exit by `-XX:+AutoCreateSharedArchive` and **never ships in an update package**, so there is nothing to copy or set permissions on. The right fix is removal.

## Changes

- `hytale_update.sh` / `hytale_start.sh`: drop the `HytaleServer.aot` staging copy
- `checks/permissions.sh`: drop `*.aot` from the binary `chmod` and its debug label

No behavior change — nothing reads that file anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)