### PR TITLE
docs: correct config.json injection path to Server/config.json

### DIFF
--- a/docs/documentation/docker.md
+++ b/docs/documentation/docker.md
@@ -73,7 +73,7 @@ Options are listed in the same order as they appear in `java -jar HytaleServer.j
 
 ## Hytale Settings (config.json)
 
-These variables directly inject values into the `home/container/config.json` file on startup.
+These variables directly inject values into the `home/container/Server/config.json` file on startup.
 
 | Variable | Description | Default |
 | :--- | :--- | :--- |

--- a/docs/documentation/docker.md
+++ b/docs/documentation/docker.md
@@ -73,7 +73,7 @@ Options are listed in the same order as they appear in `java -jar HytaleServer.j
 
 ## Hytale Settings (config.json)
 
-These variables directly inject values into the `home/container/Server/config.json` file on startup.
+These variables directly inject values into the `/home/container/Server/config.json` file on startup.
 
 | Variable | Description | Default |
 | :--- | :--- | :--- |


### PR DESCRIPTION
## Summary

Follow-up to PR #132. That PR fixed env-var config injection to target `Server/config.json` (the file the server actually reads, since it launches with `CWD=Server`), but the Docker docs still told users the variables inject into the top-level `home/container/config.json`.

Updates `docs/documentation/docker.md` to reference `home/container/Server/config.json`, so anyone troubleshooting config overrides looks at the right file.

Addresses [Copilot's review note on #132](https://github.com/deinfreu/hytale-server-container/pull/132#discussion_r3563041582).

(The README folder tree already shows `config.json` correctly nested under `Server/`, so no change needed there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)