### PR TITLE
Fix rootless server startup

### DIFF
--- a/examples/rootless-podman-quadlets/hytale.container
+++ b/examples/rootless-podman-quadlets/hytale.container
@@ -10,6 +10,10 @@ PublishPort=5520:5520/udp
 EnvironmentFile=%h/.config/containers/systemd/hytale.env
 Volume=%h/files/hytale:/home/container
 Volume=/etc/machine-id:/etc/machine-id:ro
+# Use same UID/GID in container and host
+UserNS=keep-id
+# Enable interactive terminal (Options "tty: true" and "stdin: true" in docker-compose)
+PodmanArgs=--attach stdin --tty
 # If running on an OS with SELinux, use these Volume declarations instead
 # (Create ~/files/.secrets/machine-id yourself, using dbus-uuidgen)
 #Volume=%h/files/hytale:/home/container:z

--- a/scripts/hytale/hytale_start.sh
+++ b/scripts/hytale/hytale_start.sh
@@ -99,18 +99,13 @@ run_server() {
     # This prevents the background process from being detached to /dev/null
     exec 4<&0
 
-    # 2. Start a background process that listens to channel 4 
+    # 2. Start a background process that listens to channel 4
     # and pushes everything directly into the AUTH_PIPE
     ( while read -r line <&4; do printf "%s\n" "$line" >> "$AUTH_PIPE"; done ) &
     local INPUT_PID=$!
 
     # 3. Start the Java server with channel 3 connected to the AUTH_PIPE
-    if [ -n "$RUNTIME_CMD" ]; then
-        $RUNTIME sh -c "exec 3<>\"$AUTH_PIPE\"; $java_cmd <&3 2>&1 | stdbuf -oL -eL sed 's/\r$//' | stdbuf -oL -eL tee \"$AUTH_OUTPUT_LOG\""
-    else
-        exec 3<>"$AUTH_PIPE"
-        $java_cmd <&3 2>&1 | stdbuf -oL -eL sed 's/\r$//' | stdbuf -oL -eL tee "$AUTH_OUTPUT_LOG"
-    fi
+    $RUNTIME sh -c "exec 3<>\"$AUTH_PIPE\"; $java_cmd <&3 2>&1 | stdbuf -oL -eL sed 's/\r$//' | stdbuf -oL -eL tee \"$AUTH_OUTPUT_LOG\""
 
     # 4. Clean up the processes and channels gracefully when the server stops
     kill $INPUT_PID 2>/dev/null


### PR DESCRIPTION
When starting the container, with podman rootless for example, the server wouldn't start because the Java command wasn't wrapped in quotes like when starting as root.
The container then crashed with this error
`Error: Unable to access jarfile /home/container/Server/HytaleServer.jar` 

I removed the if-else, as nothing happens when `$RUNTIME_CMD` is empty and prefixed before the startup command.

This solves one part of this issue: https://github.com/deinfreu/hytale-server-container/issues/143
I haven't yet figured out how to dynamically use another UID/GID when running the container without rebuilding. 